### PR TITLE
Fixes https://dev.plone.org/plone/ticket/11044

### DIFF
--- a/plone/openid/plugins/oid.py
+++ b/plone/openid/plugins/oid.py
@@ -122,8 +122,8 @@ class OpenIdPlugin(BasePlugin):
         from it, or a redirect from an OpenID server.
         """
         creds={}
-        identity=request.form.get("__ac_identity_url", None)
-        if identity is not None and identity != "":
+        identity=request.form.get("__ac_identity_url", "").strip() 
+        if identity != "": 
             self.initiateChallenge(identity)
             return creds
             


### PR DESCRIPTION
A user of mine was suffering mysterious login failures. The log showed:

openid consumer discovery error for identity user.myopenid.com : Normalizing identifier: Illegal characters in URI: ' ' at position 32

If a user has no concept of "trailing whitespace", it's hard to make him care about not hitting space in the wrong place.

This change fixes it.
