### PR TITLE
Including timestamp in nonce

### DIFF
--- a/plone/openid/store.py
+++ b/plone/openid/store.py
@@ -80,7 +80,7 @@ class ZopeStore(OpenIDStore):
 
 
     def useNonce(self, server_url, timestamp, salt):
-        nonce = (salt, server_url)
+        nonce = (salt, timestamp, server_url)
         if nonce in self.nonces:
             return False
 

--- a/plone/openid/tests/store.txt
+++ b/plone/openid/tests/store.txt
@@ -74,10 +74,12 @@ when the current handles are empty.
 Nonces
 ======
 
-OpenId uses nonces, which are basically ids used to track outstanding
-requests. A nonce is build up from a server URL and a salt. In order
-to be able to track old nonces which may be expired a timestamp is
-added to their registration as well.
+OpenId uses nonces, which are basically ids used to track outstanding requests.
+A nonce is build up from a server URL, a timestamp and a salt. The timestamp is
+the time that the nonce was created (to the nearest second). The salt is a
+random string that makes two nonces from the same server issued during the same
+second unique. The timestamp is also used to track when old nonces should be
+expired.
 
 Using nonces the first time results in a True response
 
@@ -86,9 +88,15 @@ Using nonces the first time results in a True response
   >>> store.useNonce("two", now, "salt")
   True
 
-
 If we try to add a nonce which already exists False should be returned:
 
   >>> store.useNonce("two", now, "salt")
   False
 
+But when there is a new request with a new timestamp, using nonces will result
+in a True for a once again:
+
+  >>> store.useNonce("two", now + 60, "salt")
+  True
+  >>> store.useNonce("two", now + 60, "salt")
+  False


### PR DESCRIPTION
Fixes https://dev.plone.org/ticket/11987 :

> Nonce should also include timestamp in
> source:plone.openid/trunk/plone/openid/store.py#L83
> This breaks with OpenID4Java for example because it uses 
> salt only when timestamps are equal between requests.

The specs may say that this is voluntary, but e.g. all store implementations in python-openid seem to store timestamp with nonce: https://github.com/openid/python-openid/tree/master/openid/store
